### PR TITLE
Redirect Player.hashCode to fix comparisons in hash

### DIFF
--- a/src/main/java/com/rezzedup/opguard/wrapper/WrappedPlayer.java
+++ b/src/main/java/com/rezzedup/opguard/wrapper/WrappedPlayer.java
@@ -68,6 +68,12 @@ class WrappedPlayer implements Player
     {
         return player.equals(object);
     }
+
+    @Override
+    public int hashCode()
+    {
+        return player.hashCode();
+    }
     
     @Override
     public boolean isOp()
@@ -1814,5 +1820,4 @@ class WrappedPlayer implements Player
     {
         return player.launchProjectile(aClass, vector);
     }
-    
 }


### PR DESCRIPTION
Many plugins depend on the use of Player.hashCode(). Especially if Java (hash) collections are used. If a plugin uses the player instance as the key, Java compares the elements with those methods.

I noticed that on PlayerJoinEvent I receive a unguarded player instance. Then if I insert it into a map and a player invokes a command I receive a guarded instance and so it cannot find the player in that map, because the results from hashCode and equals are different.